### PR TITLE
parametrize binary under test

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,5 +13,5 @@ make dockerize
 == Tests (including integration with Kafka)
 Assuming kafka is running locally on port 9092,
 ```
-KAFKA_BROKER=localhost:9092 make clean test
+SIDECAR_BINARY=$PWD/function-sidecar KAFKA_BROKER=localhost:9092 make clean test
 ```

--- a/cmd/function-sidecar_test.go
+++ b/cmd/function-sidecar_test.go
@@ -38,7 +38,7 @@ func TestIntegrationWithKafka(t *testing.T) {
 		t.Fatal("Required environment variable KAFKA_BROKER was not provided")
 	}
 
-	cmd := exec.Command("../function-sidecar")
+	cmd := exec.Command(os.Getenv("SIDECAR_BINARY"))
 	input := randString(10)
 	output := randString(10)
 	group := randString(10)


### PR DESCRIPTION
This is one solution which can enable the necessary flexibility for CI builds to work.

Signed-off-by: Felix Reyn <freyn@pivotal.io>