### PR TITLE
Improve gRPC error handling

### DIFF
--- a/cmd/function-sidecar.go
+++ b/cmd/function-sidecar.go
@@ -114,10 +114,11 @@ func main() {
 
 	carrier.Run(consumer, producer, dispatcher, output)
 
-	// trap SIGINT, SIGTERM, and SIGKILL to trigger a shutdown.
+	// trap SIGINT and SIGTERM to trigger a shutdown.
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, os.Kill)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	<-signals
+	log.Println(("Shutting Down..."))
 }
 
 func createDispatcher(protocol string) (dispatch.Dispatcher, error) {


### PR DESCRIPTION
To improve the responsiveness of sidecar shutdown, bail out on EOF or when
stream is terminating.

Delete unnecessary signal. When a process is killed, e.g. via kill -9, its
signal handlers are not driven.

Fixes https://github.com/projectriff/function-sidecar/issues/47.