### PR TITLE
Skip nil message returned on error by synchronous dispatcher

### DIFF
--- a/pkg/dispatcher/http/http.go
+++ b/pkg/dispatcher/http/http.go
@@ -41,6 +41,7 @@ func (httpDispatcher) Dispatch(in message.Message) (message.Message, error) {
 	}
 	req, err := http.NewRequest("POST", "http://localhost:8080", bytes.NewReader(in.Payload()))
 	if err != nil {
+		log.Printf("Error creating POST request to http://localhost:8080: %v", err)
 		return nil, err
 	}
 	propagateIncomingHeaders(in, req)

--- a/pkg/dispatcher/wrapper.go
+++ b/pkg/dispatcher/wrapper.go
@@ -63,6 +63,7 @@ func NewWrapper(synch SynchDispatcher) (*wrapper, error) {
 						message, err := synch.Dispatch(in)
 						if err != nil {
 							log.Printf("Error calling synch dispatcher %v\n", err)
+							return
 						}
 						propagateHeaders(in, message)
 						log.Printf("Wrapper about to forward %v\n", message)


### PR DESCRIPTION
When the HTTP dispatcher fails, it returns an error and a nil message. Without
this fix, the nil message eventually causes a SIGSEGV. Thanks Go.

Also add a missing diagnostic.

Fixes https://github.com/projectriff/function-sidecar/issues/54